### PR TITLE
add bgr8 arg when CvCopy to prevent Error when message has bgra8

### DIFF
--- a/src/face_recognition.cpp
+++ b/src/face_recognition.cpp
@@ -196,7 +196,7 @@ public:
     //convert from ros image format to opencv image format
     try
     {
-      cv_ptr = cv_bridge::toCvCopy(msg);
+      cv_ptr = cv_bridge::toCvCopy(msg, "bgr8");
     }
     catch (cv_bridge::Exception& e)
     {


### PR DESCRIPTION
This will prevent crush at equalize (when input image  topic include bgra8 )
